### PR TITLE
fix minutes date formatting

### DIFF
--- a/lib/screens/Call/components/call_ended_popup.dart
+++ b/lib/screens/Call/components/call_ended_popup.dart
@@ -106,7 +106,7 @@ Future<bool> callEndedPopup(
                           ),
                           const SizedBox(height: 4),
                           Text(
-                            "${DateFormat('HH:MM').format(DateTime.parse(appointment.start).toLocal())} horas",
+                            "${DateFormat('HH:mm').format(DateTime.parse(appointment.start).toLocal())} horas",
                             style: boldoSubTextStyle.copyWith(fontSize: 16),
                           ),
                         ],

--- a/lib/screens/booking/booking_confirm_screen.dart
+++ b/lib/screens/booking/booking_confirm_screen.dart
@@ -149,7 +149,7 @@ class _DoctorBookingInfoWidget extends StatelessWidget {
           height: 7,
         ),
         Text(
-          "${DateFormat('HH:MM').format(bookingDate)} horas",
+          "${DateFormat('HH:mm').format(bookingDate)} horas",
           style: boldoSubTextStyle.copyWith(fontSize: 16),
         ),
       ],

--- a/lib/screens/booking/booking_screen.dart
+++ b/lib/screens/booking/booking_screen.dart
@@ -215,7 +215,7 @@ class _BookingScreenState extends State<BookingScreen> {
                                         child: Padding(
                                           padding: const EdgeInsets.all(8.0),
                                           child: Text(
-                                            DateFormat('HH:MM').format(e),
+                                            DateFormat('HH:mm').format(e),
                                             textAlign: TextAlign.center,
                                             style:
                                                 boldoHeadingTextStyle.copyWith(
@@ -375,7 +375,7 @@ class _BookDoctorCard extends StatelessWidget {
                           height: 4,
                         ),
                         Text(
-                          "${DateFormat('HH:MM').format(parsedAvailability)} horas",
+                          "${DateFormat('HH:mm').format(parsedAvailability)} horas",
                           style: boldoSubTextStyle,
                         ),
                       ],


### PR DESCRIPTION
Problem:  I found various places where the date formatting was wrong. It was displaying hours and months, instead of hours and minutes.

Solution: I changed the date formatting from `HH:MM` to `HH:mm`