### PR TITLE
Fix/profile form

### DIFF
--- a/lib/provider/user_provider.dart
+++ b/lib/provider/user_provider.dart
@@ -15,6 +15,9 @@ class UserProvider with ChangeNotifier {
       _addressDescription,
       _photoUrl;
 
+  String _profileEditSuccessMessage;
+  String _profileEditErrorMessage;
+
   String get getGivenName => _givenName;
   String get getFamilyName => _familyName;
   String get getBirthDate => _birthDate;
@@ -27,6 +30,21 @@ class UserProvider with ChangeNotifier {
   String get getCity => _city;
   String get getAddressDescription => _addressDescription;
   String get getPhotoUrl => _photoUrl;
+
+  String get profileEditSuccessMessage => _profileEditSuccessMessage;
+  String get profileEditErrorMessage => _profileEditErrorMessage;
+
+  void clearProfileFormMessages() {
+    _profileEditErrorMessage = null;
+    _profileEditSuccessMessage = null;
+  }
+
+  void updateProfileEditMessages(String successMessage, String errorMessage) {
+    _profileEditSuccessMessage = successMessage;
+    _profileEditErrorMessage = errorMessage;
+    notifyListeners();
+  }
+
   void clearProvider() {
     _givenName = null;
     _familyName = null;

--- a/lib/screens/profile/address_screen.dart
+++ b/lib/screens/profile/address_screen.dart
@@ -19,8 +19,7 @@ class _AddressScreenState extends State<AddressScreen> {
   bool _validate = false;
   bool loading = false;
   String street, neighborhood, city, addressDescription;
-  String errorMessage;
-  String successMessage;
+
   final _formKey = GlobalKey<FormState>();
 
   Future<void> _updateLocation() async {
@@ -32,23 +31,23 @@ class _AddressScreenState extends State<AddressScreen> {
     }
 
     _formKey.currentState.save();
+
+    Provider.of<UserProvider>(context, listen: false)
+        .clearProfileFormMessages();
     setState(() {
-      errorMessage = null;
-      successMessage = null;
       loading = true;
     });
     Map<String, String> updateResponse = await updateProfile(context: context);
+    Provider.of<UserProvider>(context, listen: false).updateProfileEditMessages(
+        updateResponse["successMessage"], updateResponse["errorMessage"]);
     setState(() {
-      errorMessage = updateResponse["errorMessage"];
-      successMessage = updateResponse["successMessage"];
       loading = false;
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    UserProvider userProvider =
-        Provider.of<UserProvider>(context, listen: false);
+    UserProvider userProvider = Provider.of<UserProvider>(context);
     return CustomWrapper(
       children: [
         const SizedBox(height: 20),
@@ -81,6 +80,8 @@ class _AddressScreenState extends State<AddressScreen> {
                       initialValue: data ?? "",
                       label: "Calle",
                       secondaryLabel: "Opcional",
+                      onChanged: (String val) =>
+                          userProvider.setUserData(street: val),
                       changeValueCallback: (String val) {
                         userProvider.setUserData(street: val);
                       },
@@ -96,6 +97,8 @@ class _AddressScreenState extends State<AddressScreen> {
                       initialValue: data ?? "",
                       label: "Barrio",
                       secondaryLabel: "Opcional",
+                      onChanged: (String val) =>
+                          userProvider.setUserData(neighborhood: val),
                       changeValueCallback: (String val) {
                         userProvider.setUserData(neighborhood: val);
                       },
@@ -111,6 +114,8 @@ class _AddressScreenState extends State<AddressScreen> {
                       initialValue: data ?? "",
                       label: "Ciudad",
                       secondaryLabel: "Opcional",
+                      onChanged: (String val) =>
+                          userProvider.setUserData(city: val),
                       changeValueCallback: (String val) {
                         userProvider.setUserData(city: val);
                       },
@@ -127,6 +132,8 @@ class _AddressScreenState extends State<AddressScreen> {
                       maxLines: 6,
                       label: "Referencia",
                       secondaryLabel: "Opcional",
+                      onChanged: (String val) =>
+                          userProvider.setUserData(addressDescription: val),
                       changeValueCallback: (String val) {
                         userProvider.setUserData(addressDescription: val);
                       },
@@ -137,20 +144,19 @@ class _AddressScreenState extends State<AddressScreen> {
                 ),
                 const SizedBox(height: 26),
                 SizedBox(
-                  height: 18,
                   child: Column(
                     children: [
-                      if (errorMessage != null)
+                      if (userProvider.profileEditErrorMessage != null)
                         Text(
-                          errorMessage,
+                          userProvider.profileEditErrorMessage,
                           style: const TextStyle(
                             fontSize: 14,
                             color: Constants.otherColor100,
                           ),
                         ),
-                      if (successMessage != null)
+                      if (userProvider.profileEditSuccessMessage != null)
                         Text(
-                          successMessage,
+                          userProvider.profileEditSuccessMessage,
                           style: const TextStyle(
                             fontSize: 14,
                             color: Constants.primaryColor600,

--- a/lib/widgets/custom_form_input.dart
+++ b/lib/widgets/custom_form_input.dart
@@ -22,7 +22,7 @@ class CustomFormInput extends StatefulWidget {
   final String Function(String) validator;
   final Function(String) changeValueCallback;
   final bool obscureText;
-  final onChanged;
+  final Function(String) onChanged;
   final List<TextInputFormatter> inputFormatters;
   CustomFormInput(
       {Key key,
@@ -196,9 +196,7 @@ class _CustomFormInputState extends State<CustomFormInput> {
                   //keyboardType: TextInputType.emailAddress,
                   validator: widget.validator,
                   onChanged: widget.onChanged,
-                  onSaved: (String val) {
-                    widget.changeValueCallback(val);
-                  },
+                  onSaved: widget.changeValueCallback,
                 ),
               ),
             ),


### PR DESCRIPTION
## Profile Form
### This pull request deals with fixing the form in the profile screen and the address screen
Fixes #42

#### Context
The profile form is split between the profile screen and the address screen. The issue #42 showcases how the screens are not able to receive the updated values of the input fields when navigating between the screens as well as not sharing the error messages.

### Problem 1 The Input Fields values are not shared between the two screens.
The values are stored in a provider. the values are only saved when you submit form.

### Solution 1 Save the input field values in the onChange function
This way the values are updated when the user edits the input field. More details in the  commit 4c6d529

### Problem 2 The error messages are not shared between the screens.
Each screen holds its own error and success message in its internal state.

### Solution 2 Store the Error and Success messages in the provider
I moved the error and success messages into the provider so they can be shared between the screens. In addition, I also created a clearMessages and updateMessages functions in the provider so they can be called from whatever screen is submitting the form. More details in the commit 3d1a7a9

### Additional Notes
I included the success messages in the provider. Issue #42 only asks for shared error messages but the success message can also be easily shared and provides better user experience IMO.

Even though these commits fixes the #42 issue, a better user experience can be achieved by creating only one form for both screens.







