### PR TITLE
fix #52

### DIFF
--- a/lib/screens/hero/hero_screen.dart
+++ b/lib/screens/hero/hero_screen.dart
@@ -106,6 +106,7 @@ class HeroScreen extends StatelessWidget {
                   Navigator.push(
                     context,
                     MaterialPageRoute(
+                      settings: const RouteSettings(name: "/home"),
                       builder: (context) => DashboardScreen(),
                     ),
                   );
@@ -126,6 +127,7 @@ class HeroScreen extends StatelessWidget {
                 Navigator.push(
                   context,
                   MaterialPageRoute(
+                    settings: const RouteSettings(name: "/home"),
                     builder: (context) => DashboardScreen(),
                   ),
                 );


### PR DESCRIPTION
This is a proposed fix for the crash reported in #52.

### The issue
The issue seemed to be that the named route `/home` could not be found when the app was opened for the first time.

`initialRoute: onboardingCompleted ? '/home' : "/onboarding",`
Once the app is started again and the onboarding has been completed already, an initialRoute with name `/home` exists. But on the first open of the app, the initialRoute is `/onboarding`.

### The Solution

There are two buttons in the onboarding screen that lead further into the app. By adding a name to both of the `push` calls, we ensure that in all possible situations, the navigation has access to the named routes.

This is a complete fix but it seems like not totally perfect. The fact that all routs in the onboarding (and only those) have to include a named link to the home screen seems like a potential source of bugs in the future. Suggestions welcome for a more sustainable fix.