### PR TITLE
fix: await for save image picked

### DIFF
--- a/lib/screens/take_picture/take_picture_screen.dart
+++ b/lib/screens/take_picture/take_picture_screen.dart
@@ -1,7 +1,6 @@
 import 'package:camera/camera.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 
 class TakePictureScreen extends StatefulWidget {
   final List<CameraDescription> cameras;
@@ -522,10 +521,10 @@ class TakePictureScreenState extends State<TakePictureScreen> with WidgetsBindin
   void onTakePictureButtonPressed() {
     takePicture().then((XFile? file) {
       if (mounted) {
-        setState(() {
+        setState(() async {
           imageFile = file;
           print(widget.path);
-          file!.saveTo(widget.path);
+          await file!.saveTo(widget.path);
           Navigator.pop(context);
         });
         if (file != null) {


### PR DESCRIPTION
No se guardaba la imagen aún y ya se volvía a la pantalla anterior, por lo que se coloca un await para esperar el guardado de la imagen y luego volver a la pantalla de validación.