### PR TITLE
fix: dispose local video after end call

### DIFF
--- a/lib/screens/Call/video_call.dart
+++ b/lib/screens/Call/video_call.dart
@@ -219,6 +219,7 @@ class _VideoCallState extends State<VideoCall> {
     remoteRenderer.srcObject = null;
     localRenderer.dispose();
     remoteRenderer.dispose();
+    localStream?.dispose();
 
     //cleanup the peer connection
     if (peerConnection != null) peerConnection!.cleanup();


### PR DESCRIPTION
Luego de finalizar la llamada la camara seguía activo de forma local