### PR TITLE
Fix/qr scanner rotation

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -120,6 +120,8 @@ PODS:
     - nanopb/encode (= 2.30908.0)
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
+  - native_device_orientation (0.0.1):
+    - Flutter
   - package_info_plus (0.4.5):
     - Flutter
   - path_provider_ios (0.0.1):
@@ -163,6 +165,7 @@ DEPENDENCIES:
   - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - mobile_scanner (from `.symlinks/plugins/mobile_scanner/ios`)
+  - native_device_orientation (from `.symlinks/plugins/native_device_orientation/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
   - permission_handler (from `.symlinks/plugins/permission_handler/ios`)
@@ -220,6 +223,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/image_picker_ios/ios"
   mobile_scanner:
     :path: ".symlinks/plugins/mobile_scanner/ios"
+  native_device_orientation:
+    :path: ".symlinks/plugins/native_device_orientation/ios"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_ios:
@@ -264,6 +269,7 @@ SPEC CHECKSUMS:
   MLKitVision: e87dc3f2e456a6ab32361ebd985e078dd2746143
   mobile_scanner: 073e39c0c96360297389f4db68e4297a1fa58349
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
+  native_device_orientation: 3b4cfc9565a7b879cc4fde282b3e27745e852d0d
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
   path_provider_ios: 7d7ce634493af4477d156294792024ec3485acd5
   permission_handler: ccb20a9fad0ee9b1314a52b70b76b473c5f8dab0

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -36,6 +36,8 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -88,7 +88,10 @@ Future<void> main() async {
     );
   }
 
-  SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]).then(
+  SystemChrome.setPreferredOrientations([DeviceOrientation.landscapeRight,
+    DeviceOrientation.landscapeLeft,
+    DeviceOrientation.portraitUp,
+    DeviceOrientation.portraitDown,]).then(
       (value) => runApp(
           MyApp(session: session??'')));
 }

--- a/lib/screens/family/tabs/QR_scanner.dart
+++ b/lib/screens/family/tabs/QR_scanner.dart
@@ -1,8 +1,10 @@
 import 'package:boldo/blocs/user_bloc/patient_bloc.dart';
 import 'package:boldo/utils/loading_helper.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:native_device_orientation/native_device_orientation.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
 import '../../../main.dart';
@@ -23,6 +25,10 @@ class _QRScannerState extends State<QRScanner> {
 
   @override
   void initState() {
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.portraitUp,
+      DeviceOrientation.portraitDown,
+    ]);
     cameraController = MobileScannerController(
       facing: CameraFacing.back,
       torchEnabled: false,
@@ -33,6 +39,12 @@ class _QRScannerState extends State<QRScanner> {
   @override
   void dispose() {
     cameraController!.dispose();
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.landscapeRight,
+      DeviceOrientation.landscapeLeft,
+      DeviceOrientation.portraitUp,
+      DeviceOrientation.portraitDown,
+    ]);
     super.dispose();
   }
 
@@ -92,7 +104,33 @@ class _QRScannerState extends State<QRScanner> {
                   );
                   cameraController!.stop();
                   BlocProvider.of<PatientBloc>(context).add(ValidateQr(id: code?? ''));
-                  
+
+                },
+              ),
+              NativeDeviceOrientationReader(
+                useSensor: true, // --> [2]
+                builder: (ctx) {
+                  final orientation = NativeDeviceOrientationReader.orientation(ctx);
+                  int turns = 0;
+                  switch (orientation) {
+                    case NativeDeviceOrientation.portraitUp:
+                      turns = 0;
+                      break;
+                    case NativeDeviceOrientation.portraitDown:
+                      turns = 2;
+                      break;
+                    case NativeDeviceOrientation.landscapeLeft:
+                      turns = 1;
+                      break;
+                    case NativeDeviceOrientation.landscapeRight:
+                      turns = 3;
+                      break;
+                    case NativeDeviceOrientation.unknown:
+                      turns = 0;
+                      break;
+                  }
+                  // children with rotation
+                  return Container();
                 },
               ),
               if(_dataLoading)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -492,6 +492,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  native_device_orientation:
+    dependency: "direct main"
+    description:
+      name: native_device_orientation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.4"
   nested:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,7 @@ dependencies:
   crypto: ^3.0.1
   mask_text_input_formatter: ^2.3.0
   wakelock: ^0.6.1+2
+  native_device_orientation: ^1.1.4
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.3


### PR DESCRIPTION
Al colocar de forma horizontal la tablet la camara para scannear QR gira más de lo debido, por lo que hay que mantener fijo la dirección de la pantalla y rotar todos los demás elementos.