### PR TITLE
fix: remove unnecessary remove context

### DIFF
--- a/lib/network/user_repository.dart
+++ b/lib/network/user_repository.dart
@@ -631,8 +631,15 @@ class UserRepository {
       patient = Patient();
       families = [];
 
-      Navigator.of(context).pushNamedAndRemoveUntil(
-          '/onboarding', (Route<dynamic> route) => false);
+      // this will be failed if the user change environment
+      // the context was removed in the dio handle error
+      try{
+        Navigator.of(context).pushNamedAndRemoveUntil(
+            '/onboarding', (Route<dynamic> route) => false);
+      }catch (e){
+        // nothing to do
+      }
+
     }on DioError catch(ex){
       await Sentry.captureMessage(
         ex.toString(),

--- a/lib/screens/sing_in/sing_in_transition.dart
+++ b/lib/screens/sing_in/sing_in_transition.dart
@@ -59,10 +59,6 @@ class _SingInTransitionState extends State<SingInTransition> {
                   backgroundColor: Colors.redAccent,
                 ),
               );
-              _dataLoading = false;
-              Navigator.of(context).pushNamedAndRemoveUntil('/onboarding', (Route<dynamic> route) => false);
-            }
-            if(state is RedirectBackScreen){
               UserRepository().logout(context);
             }
             if(state is ChangeFamily){


### PR DESCRIPTION
Si el usuario tiene una app apuntando a un entorno y no cierra la sesión, al instalar la app apuntando a otro entorno no será posible obtener el usuario de la anterior sesión, por lo que se le lleva al HeroScreen de la app. Este manejo de excepción es resuelto por el Handler del Dio, por lo que ya no se debe de eliminar el contexto en otros lugares.